### PR TITLE
42 new metadata key name for bergamo sessions

### DIFF
--- a/.codeocean/datasets.json
+++ b/.codeocean/datasets.json
@@ -2,8 +2,8 @@
 	"version": 1,
 	"attached_datasets": [
 		{
-			"id": "e99b7b10-9779-47b8-a11e-9cc642d033a2",
-			"mount": "multiplane-ophys_749011_2024-12-03_11-51-19"
+			"id": "70dae0ae-1f5a-4016-9d08-1071e0e0b70c",
+			"mount": "bergamo-test20241204"
 		}
 	]
 }

--- a/.codeocean/datasets.json
+++ b/.codeocean/datasets.json
@@ -2,8 +2,8 @@
 	"version": 1,
 	"attached_datasets": [
 		{
-			"id": "4f5fcd89-392e-4306-8d15-718107d97dca",
-			"mount": "multiplane-ophys_737674_2024-10-04_11-56-08"
+			"id": "e99b7b10-9779-47b8-a11e-9cc642d033a2",
+			"mount": "multiplane-ophys_749011_2024-12-03_11-51-19"
 		}
 	]
 }

--- a/code/registration.py
+++ b/code/registration.py
@@ -1378,7 +1378,7 @@ def singleplane_motion_correction(
         with h5py.File(h5_file, "r") as f:
             data = f["data"][:5000]
             trial_locations = f["trial_locations"][()]
-            epoch_filenames = f["epoch_filenames"][()]
+            epoch_filenames = f["epoch_locations"][()]
         with h5py.File(debug_file, "a") as f:
             f.create_dataset("data", data=data)
             f.create_dataset("trial_locations", data=trial_locations)

--- a/code/registration.py
+++ b/code/registration.py
@@ -1319,7 +1319,7 @@ def generate_single_plane_reference(fp: Path, session) -> Path:
     """
     with h5py.File(fp, "r") as f:
         # take the first bci epoch to save out reference image TODO
-        tiff_stems = json.loads(f["trial_locations"][:][0])
+        tiff_stems = json.loads(f["epoch_locations"][:][0])
         bci_epochs = [
             i
             for i in session["stimulus_epochs"]
@@ -1385,9 +1385,12 @@ def singleplane_motion_correction(
             f.create_dataset("epoch_filenames", data=epoch_filenames)
         h5_file = debug_file
     with h5py.File(h5_file, "r") as f:
-        tiff_stems = json.loads(f["tiff_stem_location"][:][0])
-    with open(output_dir / "tiff_stem_locations.json", "w") as j:
-        json.dump(tiff_stems, j)
+        trial_locations = json.loads(f["trial_locations"][:][0])
+        epoch_locations = json.loads(f["epoch_locations"][:][0])
+    with open(output_dir / "trial_locations.json", "w") as j:
+        json.dump(trial_locations, j)
+    with open(output_dir / "epoch_locations.json", "w") as j:
+        json.dump(epoch_locations, j)
 
     return h5_file, output_dir, reference_image_fp
 

--- a/code/registration.py
+++ b/code/registration.py
@@ -1382,7 +1382,7 @@ def singleplane_motion_correction(
         with h5py.File(debug_file, "a") as f:
             f.create_dataset("data", data=data)
             f.create_dataset("trial_locations", data=trial_locations)
-            f.create_dataset("epoch_filenames", data=epoch_filenames)
+            f.create_dataset("epoch_locations", data=epoch_filenames)
         h5_file = debug_file
     with h5py.File(h5_file, "r") as f:
         trial_locations = json.loads(f["trial_locations"][:][0])

--- a/code/registration.py
+++ b/code/registration.py
@@ -1319,7 +1319,7 @@ def generate_single_plane_reference(fp: Path, session) -> Path:
     """
     with h5py.File(fp, "r") as f:
         # take the first bci epoch to save out reference image TODO
-        tiff_stems = json.loads(f["tiff_stem_location"][:][0])
+        tiff_stems = json.loads(f["trial_locations"][:][0])
         bci_epochs = [
             i
             for i in session["stimulus_epochs"]

--- a/code/registration.py
+++ b/code/registration.py
@@ -1377,11 +1377,11 @@ def singleplane_motion_correction(
         debug_file = Path("../scratch") / f"{stem}_debug.h5"
         with h5py.File(h5_file, "r") as f:
             data = f["data"][:5000]
-            tiff_stem_location = f["tiff_stem_location"][()]
+            trial_locations = f["trial_locations"][()]
             epoch_filenames = f["epoch_filenames"][()]
         with h5py.File(debug_file, "a") as f:
             f.create_dataset("data", data=data)
-            f.create_dataset("tiff_stem_location", data=tiff_stem_location)
+            f.create_dataset("trial_locations", data=trial_locations)
             f.create_dataset("epoch_filenames", data=epoch_filenames)
         h5_file = debug_file
     with h5py.File(h5_file, "r") as f:

--- a/metadata/metadata.yml
+++ b/metadata/metadata.yml
@@ -1,5 +1,5 @@
 metadata_version: 1
-name: aind-ophys-motion-correction
+name: TEST ANNOTATION aind-ophys-motion-correction
 description: This capsule performs motion correction using Suite2p. The default is
   piece-wise rigid motion correction as in NoRMCorre.
 authors:


### PR DESCRIPTION
Metadata key names for finding trial location and epoch location have been changed. Trial location is found under trial_locations and contains the location in the stitched image of each trial. Epoch location is found under epoch_locations and contains the location in the stitched image of each epoch.