### PR TITLE
fix unique_id from filename

### DIFF
--- a/code/registration.py
+++ b/code/registration.py
@@ -1599,7 +1599,7 @@ def multiplane_motion_correction(data_dir: Path, output_dir: Path, debug: bool =
         frame rate in Hz
     """
     h5_dir = [i for i in data_dir.rglob("*VI*") if i.is_dir()][0]
-    unique_id = h5_dir.name.split("_")[0]
+    unique_id = h5_dir.name
     h5_file = [i for i in h5_dir.glob(f"{h5_dir.name}.h5")][0]
     logging.info("Found raw time series to process %s", h5_file)
     session_fp = next(data_dir.rglob("session.json"), "")


### PR DESCRIPTION
remove splitting filename to keep the plane's full id.

old calc returns VISp.
after change returns VISp_0